### PR TITLE
Fixed bugs related to verification

### DIFF
--- a/whatsapp/__init__.py
+++ b/whatsapp/__init__.py
@@ -72,7 +72,7 @@ class WhatsApp(object):
         self.base_url = "https://graph.facebook.com/v18.0"
         self.url = f"{self.base_url}/{phone_number_id}/messages"
 
-        async def base():
+        async def base(*args):
             pass
         self.message_handler = base
         self.other_handler = base
@@ -96,7 +96,7 @@ class WhatsApp(object):
                 challenge = r.query_params.get("hub.challenge")
                 self.verification_handler(challenge)
                 self.other_handler(challenge)
-                return str(challenge)
+                return int(challenge)
             logging.error("Webhook Verification failed")
             await self.verification_handler(False)
             await self.other_handler(False)


### PR DESCRIPTION
Added fix for the following error-
```python
  File "/path/to/env/lib/python3.11/site-packages/whatsapp/__init__.py", line 97, in verify_endpoint
    self.verification_handler(challenge)
TypeError: WhatsApp.__init__.<locals>.base() takes 0 positional arguments but 1 was given
```
This was solved by using `*args` argument for `base`.

Additionally return type for challenge has been changed to `int` from `str` since Facebook expects just the number that is not wrapped with `\"`