### PR TITLE
fix: make error handler inherit from Exception to propagate error message

### DIFF
--- a/whatsapp/errors.py
+++ b/whatsapp/errors.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 
-class Handler:
+class Handler(Exception):
     def __init__(self, error: dict):
         self.error = error
 


### PR DESCRIPTION
Currently errors raise: 
`TypeError: exceptions must derive from BaseException`

This PR fixes that by making the error handler Inherit from Exception